### PR TITLE
Handle client has been banned from TWSE

### DIFF
--- a/pkg/client/twse/twse.go
+++ b/pkg/client/twse/twse.go
@@ -2,7 +2,9 @@ package twse
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -79,6 +81,9 @@ func (c *Client) fetch(p string, rawQuery url.Values) (map[string]json.RawMessag
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, ErrQuotaExceeded
+		}
 		return nil, fmt.Errorf("failed to query '%s': %w", u.String(), err)
 	}
 	defer resp.Body.Close()

--- a/pkg/client/twse/twse_test.go
+++ b/pkg/client/twse/twse_test.go
@@ -228,3 +228,18 @@ func TestClient_FetchDayQuotesTooFrequently(t *testing.T) {
 
 	assert.ErrorIs(t, err, ErrQuotaExceeded)
 }
+
+func TestClient_FetchDayQuotesTooFrequentlyCausingEmptyReply(t *testing.T) {
+	date := time.Date(2021, 3, 28, 0, 0, 0, 0, time.UTC)
+
+	mockHttpClient := &MockHttpClient{}
+	mockHttpClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+		u := req.URL
+		return u.Path == "/exchangeReport/MI_INDEX" && u.Query().Get("date") == "20210328"
+	})).Return(nil, io.EOF)
+
+	client := &Client{http: mockHttpClient}
+	_, err := client.FetchDayQuotes(date)
+
+	assert.ErrorIs(t, err, ErrQuotaExceeded)
+}


### PR DESCRIPTION
When the client sends requests too frequently, the TWSE server will first reply with an HTML page and then empty responses afterwards.